### PR TITLE
PCHR-2124: Add BackstopJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /node_modules/
+backstop_data/backstop.temp.json
+backstop_data/site-config.json
+backstop_data/html_report*
+backstop_data/screenshots

--- a/README.md
+++ b/README.md
@@ -55,6 +55,33 @@ and navigate to ""Support => Developer => Style Guides => My Guide"
 
 ## Tests
 
+### BackstopJS
+This extension uses [BackstopJS](https://github.com/garris/BackstopJS) to detect visual changes on the styleguide.
+
+This tool should be used for example when working on a CiviCRM theme like [shoreditch](https://github.com/civicrm/org.civicrm.shoreditch), to make sure that no regression issues or unintended changes are accidentally introduced
+
+To use BackstopJS first install the node packages
+```
+npm install
+```
+and then tell BackstopJS to take the reference screenshots
+```
+gulp backstopjs:reference
+```
+Once you are done with your changes, you can take the same screenshots again that will then be compared by the tool to spot visual differences
+```
+gulp backstopjs:test
+```
+If the visual difference are ok, you can tell BackstopJS to approve them, so that they will be used as the reference from that point forward
+```
+gulp backstopjs:approve
+```
+If you need to reopen the last html report, simply run
+```
+gulp backstop:report
+```
+
+### Protractor
 The browser-level integration tests are implemented with `protractor` and stored
 under `tests/protractor/`.  (If you have not already installed Protractor, then
 follow [the setup instructions from `protractortest.org`](http://www.protractortest.org/).)

--- a/backstop_data/backstop.tpl.json
+++ b/backstop_data/backstop.tpl.json
@@ -1,0 +1,26 @@
+{
+  "id": "CiviCRM Styleguide",
+  "viewports": [{
+    "name": "desktop",
+    "width": 1920,
+    "height": 900
+  }],
+  "scenarios": [
+    {
+      "label": "Styleguide - Bootstrap",
+      "url": "civicrm/styleguide/bootstrap",
+      "onBeforeScript": "login"
+    }
+  ],
+  "paths": {
+    "bitmaps_reference": "backstop_data/screenshots/reference",
+    "bitmaps_test": "backstop_data/screenshots/test",
+    "casper_scripts": "backstop_data/casper_scripts",
+    "html_report": "backstop_data/html_report",
+    "ci_report": "backstop_data/ci_report"
+  },
+  "casperFlags": [],
+  "engine": "phantomjs",
+  "report": ["CLI", "browser"],
+  "debug": false
+}

--- a/backstop_data/casper_scripts/login.js
+++ b/backstop_data/casper_scripts/login.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = function (casper) {
+  var config = require('../site-config');
+  var loginFormSelector = 'form#user-login-form';
+
+  casper
+    .echo('Logging in before starting...', 'INFO')
+    .thenOpen(config.url + '/welcome-page', function () {
+      casper.then(function () {
+        casper.waitForSelector(loginFormSelector, function () {
+          casper.waitWhileSelector(loginFormSelector, function () {
+            casper.echo('Logged in', 'INFO');
+          }, function () {
+            casper.echo('Login form visible and timeout reached!', 'RED_BAR');
+          }, 5000);
+          casper.fill(loginFormSelector, config.credentials, true);
+        }, function () {
+          casper.echo('Login form not found!', 'RED_BAR');
+        }, 8000);
+      });
+  });
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,14 @@
 var backstopjs = require('backstopjs');
 var civicrmScssRoot = require('civicrm-scssroot')();
+var Promise = require('es6-promise').Promise;
 var fs = require('fs');
-var _ = require('lodash');
 var gulp = require('gulp');
 var clean = require('gulp-clean');
 var color = require('gulp-color');
 var file = require('gulp-file');
 var bulk = require('gulp-sass-bulk-import');
 var sass = require('gulp-sass');
+var _ = require('lodash');
 var argv = require('yargs').argv;
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,21 +1,145 @@
+var backstopjs = require('backstopjs');
+var civicrmScssRoot = require('civicrm-scssroot')();
+var fs = require('fs');
+var _ = require('lodash');
 var gulp = require('gulp');
+var clean = require('gulp-clean');
+var color = require('gulp-color');
+var file = require('gulp-file');
 var bulk = require('gulp-sass-bulk-import');
 var sass = require('gulp-sass');
-var civicrmScssRoot = require('civicrm-scssroot')();
+var argv = require('yargs').argv;
 
-gulp.task('sass', function () {
-  civicrmScssRoot.updateSync();
-  gulp.src('scss/*.scss')
-    .pipe(bulk())
-    .pipe(sass({
-      includePaths: civicrmScssRoot.getPath(),
-      outputStyle: 'compressed'
-    }).on('error', sass.logError))
-    .pipe(gulp.dest('css/'));
-});
+/**
+ * Sass tasks
+ */
+(function () {
+  gulp.task('sass', function () {
+    civicrmScssRoot.updateSync();
+    gulp.src('scss/*.scss')
+      .pipe(bulk())
+      .pipe(sass({
+        includePaths: civicrmScssRoot.getPath(),
+        outputStyle: 'compressed'
+      }).on('error', sass.logError))
+      .pipe(gulp.dest('css/'));
+  });
+}());
+
+/**
+ * BackstopJS tasks
+ */
+(function () {
+  var backstopDir = 'backstop_data/';
+  var files = { config: 'site-config.json', tpl: 'backstop.tpl.json' };
+  var configTpl = {
+    "url": "http://%{site-host}",
+    "credentials": { "name": "%{user-name}", "pass": "%{user-password}" }
+  };
+
+  gulp.task('backstopjs:reference', function (done) {
+    runBackstopJS('reference').then(function () {
+      done();
+    });
+  });
+
+  gulp.task('backstopjs:test', function (done) {
+    runBackstopJS('test').then(function () {
+      done();
+    });
+  });
+
+  gulp.task('backstopjs:report', function (done) {
+    runBackstopJS('openReport').then(function () {
+      done();
+    });
+  });
+
+  gulp.task('backstopjs:approve', function (done) {
+    runBackstopJS('approve').then(function () {
+      done();
+    });
+  });
+
+  /**
+   * Checks if the site config file is in the backstopjs folder
+   * If not, it creates a template for it
+   *
+   * @return {Boolean} [description]
+   */
+  function isConfigFilePresent() {
+    var check = true;
+
+    try {
+      fs.readFileSync(backstopDir + files.config);
+    } catch (err) {
+      fs.writeFileSync(backstopDir + files.config, JSON.stringify(configTpl, null, 2));
+      check = false;
+    }
+
+    return check;
+  }
+
+  /**
+   * Runs backstopJS with the given command.
+   *
+   * @param  {string} command
+   * @return {Promise}
+   */
+  function runBackstopJS(command) {
+    var destFile = 'backstop.temp.json';
+
+    if (!isConfigFilePresent()) {
+      console.log(color(
+        "No site-config.json file detected!\n" +
+        "One has been created for you under " + backstopDir + "\n" +
+        "Please insert the real value for each placholder and try again", "RED"
+      ));
+
+      return Promise.reject();
+    }
+
+    return new Promise(function (resolve) {
+      gulp.src(backstopDir + files.tpl)
+      .pipe(file(destFile, tempFileContent()))
+      .pipe(gulp.dest(backstopDir))
+      .on('end', function () {
+        var promise = backstopjs(command, {
+          configPath: backstopDir + destFile,
+          filter: argv.filter
+        })
+        .catch(_.noop).then(function () { // equivalent to .finally()
+          gulp.src(backstopDir + destFile, { read: false }).pipe(clean());
+        });
+
+        resolve(promise);
+      });
+    });
+  }
+
+  /**
+   * Creates the content of the config temporary file that will be fed to BackstopJS
+   * The content is the mix of the config template and the list of scenarios
+   * under the scenarios/ folder
+   *
+   * @return {string}
+   */
+  function tempFileContent() {
+    var config = JSON.parse(fs.readFileSync(backstopDir + files.config));
+    var tpl = JSON.parse(fs.readFileSync(backstopDir + files.tpl));
+
+    tpl.scenarios = tpl.scenarios.map(function (scenario) {
+      scenario.url = config.url + '/' + scenario.url;
+
+      return scenario;
+    });
+
+    return JSON.stringify(tpl);
+  }
+}());
 
 gulp.task('watch', function () {
-    gulp.watch('scss/**/*.scss', ['sass']);
+  gulp.watch('scss/**/*.scss', ['sass']);
 });
 
-gulp.task('default', ['sass', 'watch']);;
+gulp.task('default', ['sass', 'watch']);

--- a/package.json
+++ b/package.json
@@ -9,11 +9,16 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "backstopjs": "^2.6.11",
     "civicrm-cv": "civicrm/cv-nodejs",
     "civicrm-scssroot": "git://github.com/totten/civicrm-scssroot.git#v0.1.1",
     "gulp": "^3.9.0",
+    "gulp-clean": "^0.3.2",
+    "gulp-color": "0.0.1",
+    "gulp-file": "^0.3.0",
     "gulp-sass": "^2.1.0",
     "gulp-sass-bulk-import": "^0.3.2",
-    "gulp-sass-glob": "0.0.2"
+    "gulp-sass-glob": "0.0.2",
+    "lodash": "^4.17.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "backstopjs": "^2.6.11",
     "civicrm-cv": "civicrm/cv-nodejs",
     "civicrm-scssroot": "git://github.com/totten/civicrm-scssroot.git#v0.1.1",
+    "es6-promise": "^4.1.0",
     "gulp": "^3.9.0",
     "gulp-clean": "^0.3.2",
     "gulp-color": "0.0.1",


### PR DESCRIPTION
This PR adds a gulp-based setup for [backstopjs](https://github.com/garris/BackstopJS), so that a frontend dev can test regression issues when working on a theme

These are the commands that are introduced
```bash
gulp backstop:reference
gulp backstop:test
gulp backstop:report
gulp backstop:approve
```

For now the only scenario added is for the "Styleguide - Bootstap" page, the only page currently functioning in the styleguide