### PR TITLE
PCHR-1439: Updates to the styleguide

### DIFF
--- a/guides/bootstrap/markup/base/headings.html
+++ b/guides/bootstrap/markup/base/headings.html
@@ -1,6 +1,3 @@
-<div class="page-header">
-  <h1>Page Header <small>With Small Text</small></h1>
-</div>
 <h1>h1. OpenSans Semibold 24px <small>Secondary text</small></h1>
 <h2>h2. OpenSans Semibold 18px <small>Secondary text</small></h2>
 <h3>h3. OpenSans Semibold 16px <small>Secondary text</small></h3>

--- a/guides/bootstrap/markup/patterns/page-header-with-status.html
+++ b/guides/bootstrap/markup/patterns/page-header-with-status.html
@@ -1,0 +1,15 @@
+<div class="page-header page-header-primary">
+  <h1>Primary <small>Subtext</small></h1>
+</div>
+<div class="page-header page-header-success">
+  <h1>Success <small>Subtext</small></h1>
+</div>
+<div class="page-header page-header-info">
+  <h1>Info <small>Subtext</small></h1>
+</div>
+<div class="page-header page-header-warning">
+  <h1>Warning <small>Subtext</small></h1>
+</div>
+<div class="page-header page-header-danger">
+  <h1>Danger <small>Subtext</small></h1>
+</div>

--- a/guides/bootstrap/markup/patterns/panels-with-nested-panel.html
+++ b/guides/bootstrap/markup/patterns/panels-with-nested-panel.html
@@ -10,14 +10,12 @@
     </div>
   </div>
   <div id="show-more-2" class="collapse panel panel-nested panel-default">
-    <div class="panel-subheading">
-      <ul class="nav nav-tabs">
-        <li><a href="#home-3" data-toggle="tab">Home</a></li>
-        <li class="active"><a href="#profile-3" data-toggle="tab">Profile</a></li>
-        <li><a href="#messages-3" data-toggle="tab">Messages</a></li>
-        <li><a href="#settings-3" data-toggle="tab">Settings</a></li>
-      </ul>
-    </div>
+    <ul class="nav nav-tabs">
+      <li><a href="#home-3" data-toggle="tab">Home</a></li>
+      <li class="active"><a href="#profile-3" data-toggle="tab">Profile</a></li>
+      <li><a href="#messages-3" data-toggle="tab">Messages</a></li>
+      <li><a href="#settings-3" data-toggle="tab">Settings</a></li>
+    </ul>
     <div class="tab-content">
       <div class="tab-pane" id="home-3">Home content</div>
       <div class="tab-pane active" id="profile-3">Profile content</div>

--- a/guides/bootstrap/markup/patterns/panels-with-tabs.html
+++ b/guides/bootstrap/markup/patterns/panels-with-tabs.html
@@ -2,14 +2,12 @@
   <div class="panel-heading">
     <h3 class="panel-title">Horizontal tabs</h3>
   </div>
-  <div class="panel-subheading">
-    <ul class="nav nav-tabs">
-      <li><a href="#home-1" data-toggle="tab">Home</a></li>
-      <li class="active"><a href="#profile-1" data-toggle="tab">Profile</a></li>
-      <li><a href="#messages-1" data-toggle="tab">Messages</a></li>
-      <li><a href="#settings-1" data-toggle="tab">Settings</a></li>
-    </ul>
-  </div>
+  <ul class="nav nav-tabs">
+    <li><a href="#home-1" data-toggle="tab">Home</a></li>
+    <li class="active"><a href="#profile-1" data-toggle="tab">Profile</a></li>
+    <li><a href="#messages-1" data-toggle="tab">Messages</a></li>
+    <li><a href="#settings-1" data-toggle="tab">Settings</a></li>
+  </ul>
   <div class="tab-content">
     <div class="tab-pane" id="home-1">Home content</div>
     <div class="tab-pane active" id="profile-1">Profile content</div>

--- a/guides/bootstrap/markup/patterns/tabs.html
+++ b/guides/bootstrap/markup/patterns/tabs.html
@@ -1,0 +1,48 @@
+<h2>Tab with full-width table</h2>
+<div>
+  <ul class="nav nav-tabs" role="tablist">
+    <li><a href>Home</a></li>
+    <li class="active"><a href>Profile</a></li>
+    <li><a href>Messages</a></li>
+    <li><a href>Settings</a></li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane" id="home">...</div>
+    <div class="tab-pane active" id="profile">
+      <div class="table-tab">
+        <table class="table">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Column Title</th>
+              <th>Column Title</th>
+              <th>Column Title</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td align="center"><input type="checkbox"></td>
+              <td>Evan Spencer</td>
+              <td><a href="#">schiller_madelynn@yahoo.com</a></td>
+              <td>Nicolaston</td>
+            </tr>
+            <tr>
+              <td align="center"><input type="checkbox"></td>
+              <td><a href="#">Hover Lipsum</a></td>
+              <td><a href="#">cummerata.carmella@weber.net</a></td>
+              <td>Woodrowville</td>
+            </tr>
+            <tr>
+              <td align="center"><input type="checkbox"></td>
+              <td>Cynthia Houston</td>
+              <td><a href="#">beverly.doyle@eichmann.org</a></td>
+              <td>New Zechariahmouth</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="tab-pane" id="messages">...</div>
+    <div class="tab-pane" id="settings">...</div>
+  </div>
+</div>

--- a/guides/bootstrap/usage/patterns/page-header-with-status.html
+++ b/guides/bootstrap/usage/patterns/page-header-with-status.html
@@ -1,0 +1,1 @@
+<p>This is how the element is used:</p>

--- a/guides/bootstrap/usage/patterns/tabs.html
+++ b/guides/bootstrap/usage/patterns/tabs.html
@@ -1,0 +1,1 @@
+<p>This is how the element is used:</p>


### PR DESCRIPTION
This PR contains changes to the styleguide, related mostly to the changes done on the Shoreditch theme [here](https://github.com/compucorp/org.civicrm.shoreditch/pull/14)

## `.page-header` variants
<img width="800" alt="page-header-sg" src="https://cloud.githubusercontent.com/assets/6400898/26527043/a9d12886-438b-11e7-8bb6-b0d919aa006c.png">

The style guide contains now the contextual variations of the `.page-header` component

## `.table-tab` variant
<img width="800" alt="tab-with-table-sg" src="https://cloud.githubusercontent.com/assets/6400898/26527044/b17cdfd0-438b-11e7-89e9-83cff361af7d.png">

The style guide contains now an example of a tab containing a full-width table in it

## Use default bootstrap markup for tabbed panels
The examples of tabbed panels (= panels containing tabs) now use the default bootstrap markup instead of the custom one that was initially implemented