### PR TITLE
PCHR-2030: Default outline buttons added

### DIFF
--- a/guides/bootstrap/markup/patterns/buttons-outlined.html
+++ b/guides/bootstrap/markup/patterns/buttons-outlined.html
@@ -1,4 +1,5 @@
 <p class="sg-btn-list">
+  <button type="button" class="btn btn-default-outline">Default</button>
   <button type="button" class="btn btn-primary-outline">Primary</button>
   <button type="button" class="btn btn-secondary-outline">Secondary</button>
   <button type="button" class="btn btn-success-outline">Success</button>
@@ -11,6 +12,13 @@
 <div class="row sg-row">
   <div class="col-sm-4">
     <div class="btn-group">
+      <button type="button" class="btn btn-default-outline">Button</button>
+      <button type="button" class="btn btn-default-outline">Button</button>
+      <button type="button" class="btn btn-default-outline">Button</button>
+    </div>
+  </div>
+  <div class="col-sm-4">
+    <div class="btn-group">
       <button type="button" class="btn btn-primary-outline">Button</button>
       <button type="button" class="btn btn-primary-outline">Button</button>
       <button type="button" class="btn btn-primary-outline">Button</button>
@@ -21,17 +29,17 @@
       <button type="button" class="btn btn-secondary-outline">Button</button>
       <button type="button" class="btn btn-secondary-outline">Button</button>
       <button type="button" class="btn btn-secondary-outline">Button</button>
-    </div>
-  </div>
-  <div class="col-sm-4">
-    <div class="btn-group">
-      <button type="button" class="btn btn-success-outline">Button</button>
-      <button type="button" class="btn btn-success-outline">Button</button>
-      <button type="button" class="btn btn-success-outline">Button</button>
     </div>
   </div>
 </div>
 <div class="row">
+  <div class="col-sm-4">
+    <div class="btn-group">
+      <button type="button" class="btn btn-success-outline">Button</button>
+      <button type="button" class="btn btn-success-outline">Button</button>
+      <button type="button" class="btn btn-success-outline">Button</button>
+    </div>
+  </div>
   <div class="col-sm-4">
     <div class="btn-group">
       <button type="button" class="btn btn-warning-outline">Button</button>

--- a/guides/bootstrap/markup/patterns/buttons-with-icon.html
+++ b/guides/bootstrap/markup/patterns/buttons-with-icon.html
@@ -27,6 +27,9 @@
 
 <h2>Outlined</h2>
 <p class="sg-btn-list">
+  <button type="button" class="btn btn-default-outline">
+    <span class="btn-icon"><i class="fa fa-plus"></i></span> Default
+  </button>
   <button type="button" class="btn btn-primary-outline">
     <span class="btn-icon"><i class="fa fa-plus"></i></span> Primary
   </button>


### PR DESCRIPTION
## Overview

New HTML buttons added for Default Outlined button. Style was updated in https://github.com/compucorp/org.civicrm.shoreditch/pull/21

## Screenshot

![20301](https://user-images.githubusercontent.com/5058867/27791983-3df2bca0-6015-11e7-9b29-6022e0d41ac7.gif)
