### PR TITLE
PCHR-3426: Remove forcing exactly one space after colon in SASS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11070,9 +11070,9 @@
       }
     },
     "stylelint-scss": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-2.3.0.tgz",
-      "integrity": "sha512-gYLw1jma/BUZ9eQ3hsrL/7bddQN2BJ13oSp0A0kOqje4hBrSCrUjf7rmpnK8taRWoU3KASwMo4apWg+YopDK5Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-2.5.0.tgz",
+      "integrity": "sha512-+joZpza5nQxAyGwzRMancFEl0EH9+1Vy88YzBghRMS0wHulzDPE9fEkBi6ZOlz+I3tYIBI4x9NbqO5/LkbeE3Q==",
       "dev": true,
       "requires": {
         "lodash": "4.17.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "rules": {
       "max-nesting-depth": 3,
       "no-extra-semicolons": true,
-      "no-duplicate-selectors": true
+      "no-duplicate-selectors": true,
+      "scss/dollar-variable-colon-space-after": "at-least-one-space"
     }
   },
   "devDependencies": {
@@ -54,7 +55,7 @@
     "stylelint": "^8.4.0",
     "stylelint-config-sass-guidelines": "^4.1.0",
     "stylelint-order": "^0.8.0",
-    "stylelint-scss": "^2.3.0",
+    "stylelint-scss": "^2.5.0",
     "yargs": "^11.0.0"
   }
 }


### PR DESCRIPTION
This PR simply allows developers to add as much spaces as they need after colon. The good example of why several spaces may be needed is:

```
// Color variables
$red:   #ff0000;
$green: #00ff00;
```