### PR TITLE
PCHR-4191: Add left-side labeled checkbox switches

### DIFF
--- a/guides/bootstrap/markup/patterns/checkbox-switch.html
+++ b/guides/bootstrap/markup/patterns/checkbox-switch.html
@@ -1,90 +1,110 @@
-<label class="control-label">Status</label>
-<div class="checkbox checkbox-switch">
-  <label>
-    <input type="checkbox">
-    <span class="checkbox-switch-label">Unchecked</span>
-  </label>
-</div>
-<div class="checkbox checkbox-switch">
-  <label>
-    <input type="checkbox" checked>
-    <span class="checkbox-switch-label">Checked</span>
-  </label>
-</div>
-<label class="control-label">Availability</label>
-<div class="checkbox checkbox-switch">
-  <label>
-    <input type="checkbox" disabled>
-    <span class="checkbox-switch-label">Disabled</span>
-  </label>
-</div>
-<div class="checkbox checkbox-switch">
-  <label>
-    <input type="checkbox" disabled checked>
-    <span class="checkbox-switch-label">Disabled and checked</span>
-  </label>
-</div>
-<label class="control-label">
-  Sizes <span class="text-muted">(via classes)</span>
-</label>
-<div class="checkbox checkbox-switch checkbox-switch-sm">
-  <label>
-    <input type="checkbox" checked><span class="checkbox-switch-label">Small</span>
-  </label>
-</div>
-<div class="checkbox checkbox-switch checkbox-switch-lg">
-  <label>
-    <input type="checkbox" checked><span class="checkbox-switch-label">Large</span>
-  </label>
-</div>
-<label class="control-label">
-  Sizes <span class="text-muted">(via form groups)</span>
-</label>
-<div class="form-group form-group-sm">
-  <div class="checkbox checkbox-switch">
-    <label>
-      <input type="checkbox" checked><span class="checkbox-switch-label">Small</span>
-    </label>
+<div class="row">
+  <div class="col-md-3">
+    <h2>Status</h2>
+    <div class="checkbox checkbox-switch">
+      <label>
+        <input type="checkbox">
+        <span class="checkbox-switch-label">Unchecked</span>
+      </label>
+    </div>
+    <div class="checkbox checkbox-switch">
+      <label>
+        <input type="checkbox" checked>
+        <span class="checkbox-switch-label">Checked</span>
+      </label>
+    </div>
+    <h2>Availability</h2>
+    <div class="checkbox checkbox-switch">
+      <label>
+        <input type="checkbox" disabled>
+        <span class="checkbox-switch-label">Disabled</span>
+      </label>
+    </div>
+    <div class="checkbox checkbox-switch">
+      <label>
+        <input type="checkbox" disabled checked>
+        <span class="checkbox-switch-label">Disabled and checked</span>
+      </label>
+    </div>
   </div>
-</div>
-<div class="form-group form-group-lg">
-  <div class="checkbox checkbox-switch">
-    <label>
-      <input type="checkbox" checked><span class="checkbox-switch-label">Large</span>
-    </label>
-  </div>
-</div>
-<label class="control-label">Context</label>
-<div class="checkbox checkbox-switch checkbox-switch-success">
-  <label>
-    <input type="checkbox" checked><span class="checkbox-switch-label">Success</span>
-  </label>
-</div>
-<div class="checkbox checkbox-switch checkbox-switch-warning">
-  <label>
-    <input type="checkbox" checked><span class="checkbox-switch-label">Warning</span>
-  </label>
-</div>
-<div class="checkbox checkbox-switch checkbox-switch-danger">
-  <label>
-    <input type="checkbox" checked><span class="checkbox-switch-label">Danger</span>
-  </label>
-</div>
-<div class="checkbox checkbox-switch checkbox-switch-info">
-  <label>
-    <input type="checkbox" checked><span class="checkbox-switch-label">Info</span>
-  </label>
-</div>
-<label class="control-label">Left-sided label</label>
-<form class="form-horizontal">
-  <div class="form-group">
-    <label for="checkbox" class="col-sm-1 control-label">Checkbox</label>
-    <div class="col-sm-11">
-      <div class="checkbox checkbox-switch checkbox-switch-info">
+  <div class="col-md-3">
+    <h2>
+      Sizes <span class="text-muted">(via classes)</span>
+    </h2>
+    <div class="checkbox checkbox-switch checkbox-switch-sm">
+      <label>
+        <input type="checkbox" checked><span class="checkbox-switch-label">Small</span>
+      </label>
+    </div>
+    <div class="checkbox checkbox-switch checkbox-switch-lg">
+      <label>
+        <input type="checkbox" checked><span class="checkbox-switch-label">Large</span>
+      </label>
+    </div>
+    <h2>
+      Sizes <span class="text-muted">(via form groups)</span>
+    </h2>
+    <div class="form-group form-group-sm">
+      <div class="checkbox checkbox-switch">
         <label>
-          <input type="checkbox" checked><span class="checkbox-switch-label"></span>
+          <input type="checkbox" checked><span class="checkbox-switch-label">Small</span>
+        </label>
+      </div>
+    </div>
+    <div class="form-group form-group-lg">
+      <div class="checkbox checkbox-switch">
+        <label>
+          <input type="checkbox" checked><span class="checkbox-switch-label">Large</span>
         </label>
       </div>
     </div>
   </div>
-</form>
+  <div class="col-md-3">
+    <h2>Context</h2>
+    <div class="checkbox checkbox-switch checkbox-switch-success">
+      <label>
+        <input type="checkbox" checked><span class="checkbox-switch-label">Success</span>
+      </label>
+    </div>
+    <div class="checkbox checkbox-switch checkbox-switch-warning">
+      <label>
+        <input type="checkbox" checked><span class="checkbox-switch-label">Warning</span>
+      </label>
+    </div>
+    <div class="checkbox checkbox-switch checkbox-switch-danger">
+      <label>
+        <input type="checkbox" checked><span class="checkbox-switch-label">Danger</span>
+      </label>
+    </div>
+    <div class="checkbox checkbox-switch checkbox-switch-info">
+      <label>
+        <input type="checkbox" checked><span class="checkbox-switch-label">Info</span>
+      </label>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <h2>Left-sided label</h2>
+    <form class="form-horizontal">
+      <div class="form-group">
+        <label for="checkbox" class="col-sm-4 control-label">Checkbox</label>
+        <div class="col-sm-8">
+          <div class="checkbox checkbox-switch checkbox-switch-info">
+            <label>
+              <input type="checkbox" checked><span class="checkbox-switch-label"></span>
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="checkbox" class="col-sm-4 control-label">Checkbox</label>
+        <div class="col-sm-8">
+          <div class="checkbox checkbox-switch checkbox-switch-info">
+            <label>
+              <input type="checkbox" checked><span class="checkbox-switch-label">with right label</span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/guides/bootstrap/markup/patterns/checkbox-switch.html
+++ b/guides/bootstrap/markup/patterns/checkbox-switch.html
@@ -75,3 +75,16 @@
     <input type="checkbox" checked><span class="checkbox-switch-label">Info</span>
   </label>
 </div>
+<label class="control-label">Left-sided label</label>
+<form class="form-horizontal">
+  <div class="form-group">
+    <label for="checkbox" class="col-sm-1 control-label">Checkbox</label>
+    <div class="col-sm-11">
+      <div class="checkbox checkbox-switch checkbox-switch-info">
+        <label>
+          <input type="checkbox" checked><span class="checkbox-switch-label"></span>
+        </label>
+      </div>
+    </div>
+  </div>
+</form>


### PR DESCRIPTION
## Overview

This PR adds **left-side labeled** checkbox switchers. Also it condenses the styles by splitting them in 4 columns.

## Before

![image](https://user-images.githubusercontent.com/3973243/47077527-0b36c200-d1f9-11e8-927a-6987f7f8cdac.png)

## After

![image](https://user-images.githubusercontent.com/3973243/47077824-b182c780-d1f9-11e8-920b-d9cbe9156b61.png)
